### PR TITLE
Sleep between `aws lambda` to avoid ResourceConflictException

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -22,6 +22,8 @@ if [ "$FLG_FNAME" = "TRUE" ]; then
       --zip-file fileb://lambda_function.zip \
       --region ap-northeast-1 \
       --publish
+      
+  sleep 5
 
   echo "set channel url: $VALUE_CURL"
   aws lambda update-function-configuration \


### PR DESCRIPTION
`aws lambda` が2度実行されますが、1回目のあとすぐに2回目が実行されることで `ResourceConflictException` が発生することがあったため、綺麗な解決策ではないですがSleepを挟むことを提案します。